### PR TITLE
add backlight pin override

### DIFF
--- a/docs/rpi-display-overlay.dts
+++ b/docs/rpi-display-overlay.dts
@@ -73,10 +73,12 @@
 		};
 	};
 	__overrides__ {
-		speed =   <&rpidisplay>,"spi-max-frequency:0";
-		rotate =  <&rpidisplay>,"rotate:0";
-		fps =     <&rpidisplay>,"fps:0";
-		debug =   <&rpidisplay>,"debug:0";
-		xohms =   <&rpidisplay_ts>,"ti,x-plate-ohms;0";
+		speed =     <&rpidisplay>,"spi-max-frequency:0";
+		rotate =    <&rpidisplay>,"rotate:0";
+		fps =       <&rpidisplay>,"fps:0";
+		debug =     <&rpidisplay>,"debug:0";
+		xohms =     <&rpidisplay_ts>,"ti,x-plate-ohms;0";
+		backlight = <&rpidisplay>,"led-gpios:4",
+		            <&rpi_display_pins>,"brcm,pins:0";
 	};
 };


### PR DESCRIPTION
In your FAQ - https://github.com/watterott/RPi-Display/blob/master/docs/FAQ.md#can-i-use-the-rpi-display-together-with-a-hifiberry

It mentions changing pin to GPIO 12 for backlight (instead of GPIO18).

This change adds an override parameter to the overlay to allow changing the backlight pin.

This can then be used with:
dtoverlay=rpi-display,backlight=12